### PR TITLE
feat: generate environment variables for projects

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(clap::Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -24,6 +25,8 @@ pub(crate) enum ProjectCommands {
     Exec(Exec),
     /// Display the project structure information
     Info(Info),
+    /// Generate environment variables with the project's structure
+    GenerateEnv(Env),
 }
 
 #[derive(clap::Args, Debug)]
@@ -48,4 +51,32 @@ pub(crate) enum DisplayType {
     Print,
     Json,
     Ron,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct Env {
+    #[clap(subcommand)]
+    pub env_type: EnvType,
+}
+
+#[derive(clap::Args, Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct DotEnv {
+    /// Whether or not to prepend `export` to each line
+    #[clap(long, short)]
+    pub export: bool,
+}
+
+#[derive(clap::Args, Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct DotEnvDirectory {
+    /// The directory to write the environment variables to
+    #[clap(long, short, default_value = ".direnv/env")]
+    pub directory: PathBuf,
+}
+
+#[derive(clap::Subcommand, Clone, Debug, Deserialize, Serialize)]
+pub(crate) enum EnvType {
+    /// A .env file
+    DotEnv(DotEnv),
+    /// A directory with files for each environment variable
+    Directory(DotEnvDirectory),
 }

--- a/crates/project-base-directory/src/lib.rs
+++ b/crates/project-base-directory/src/lib.rs
@@ -100,6 +100,43 @@ impl Project {
 
         Ok(value)
     }
+
+    /// Retrieve the project information as a HashMap composed of the environment variables as keys
+    /// and their values as values.
+    pub fn project_hashmap(&self) -> std::collections::HashMap<String, Option<String>> {
+        let mut hashmap = std::collections::HashMap::new();
+
+        hashmap.insert(
+            constants::PROJECT_ROOT.to_string(),
+            self.root_directory
+                .as_ref()
+                .map(|p| p.to_str().unwrap().to_string()),
+        );
+        hashmap.insert(
+            constants::PROJECT_DATA_HOME.to_string(),
+            self.data_home
+                .as_ref()
+                .map(|p| p.to_str().unwrap().to_string()),
+        );
+        hashmap.insert(
+            constants::PROJECT_CONFIG_HOME.to_string(),
+            self.config_home
+                .as_ref()
+                .map(|p| p.to_str().unwrap().to_string()),
+        );
+        hashmap.insert(
+            constants::PROJECT_CACHE.to_string(),
+            self.cache_home
+                .as_ref()
+                .map(|p| p.to_str().unwrap().to_string()),
+        );
+        hashmap.insert(
+            constants::PROJECT_ID.to_string(),
+            self.project_id.as_ref().map(|p| p.to_string()),
+        );
+
+        hashmap
+    }
 }
 
 /// An absolute path that points to the project root directory.


### PR DESCRIPTION
The `generate-env` command assists in managing environment variables for a project. This is useful for getting a project established, for example if you want to start using the environment variables for a project then you can generate a .env file that may be sourced. Alternatively this can create a directory of files named after the environment variable names (which is the primary method I wrote this for).